### PR TITLE
Feat/update comment

### DIFF
--- a/github-comment.yaml
+++ b/github-comment.yaml
@@ -5,7 +5,7 @@ post:
   hello:
     # update: 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"'
     template: |
-      $Hello: foo {{ "hello!" | upper | repeat 5 }}
+      $Hello: foo {{ "hello!" | upper | repeat 5 }} {{Env "HELLO"}}
 
 exec:
   hello:

--- a/github-comment.yaml
+++ b/github-comment.yaml
@@ -10,6 +10,7 @@ post:
 exec:
   hello:
     - when: ExitCode != 0
+      # update: 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"'
       template: |
         failure
         exit code: {{.ExitCode}}
@@ -17,6 +18,7 @@ exec:
         stderr: {{.Stderr}}
         combined output: {{.CombinedOutput}}
     - when: true
+      # update: 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"'
       template: |
         exit code: {{.ExitCode}}
         stdout: {{.Stdout}}

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -152,7 +152,7 @@ type Platform interface {
 	CI() string
 }
 
-func (ctrl *PostController) contains(elems []string, v string) bool {
+func contains(elems []string, v string) bool {
 	for _, s := range elems {
 		if v == s {
 			return true
@@ -213,7 +213,7 @@ func (ctrl *PostController) getCommentParams(ctx context.Context, opts *option.P
 		opts.Template = tpl.Template
 		opts.TemplateForTooLong = tpl.TemplateForTooLong
 		opts.EmbeddedVarNames = tpl.EmbeddedVarNames
-		if !ctrl.contains(opts.EmbeddedVarNames, "target") {
+		if !contains(opts.EmbeddedVarNames, "target") {
 			opts.EmbeddedVarNames = append(opts.EmbeddedVarNames, "target")
 		}
 		if opts.UpdateCondition == "" {

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -51,7 +51,8 @@ func (ctrl *PostController) Post(ctx context.Context, opts *option.PostOptions) 
 }
 
 func (ctrl *PostController) setUpdatedCommentID(ctx context.Context, cmt *github.Comment, updateCondition string) error { //nolint:funlen
-	prg, err := ctrl.Expr.Compile(updateCondition)
+	custom_updateCondition := fmt.Sprintf("%s && Comment.Meta.Vars.target == \"%s\"", updateCondition, ctrl.Config.Vars["target"])
+	prg, err := ctrl.Expr.Compile(custom_updateCondition)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
@@ -151,6 +152,15 @@ type Platform interface {
 	CI() string
 }
 
+func (ctrl *PostController) contains(elems []string, v string) bool {
+	for _, s := range elems {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
 func (ctrl *PostController) getCommentParams(ctx context.Context, opts *option.PostOptions) (*github.Comment, error) { //nolint:funlen,cyclop,gocognit
 	if ctrl.Platform != nil {
 		if err := ctrl.Platform.ComplementPost(opts); err != nil {
@@ -203,6 +213,9 @@ func (ctrl *PostController) getCommentParams(ctx context.Context, opts *option.P
 		opts.Template = tpl.Template
 		opts.TemplateForTooLong = tpl.TemplateForTooLong
 		opts.EmbeddedVarNames = tpl.EmbeddedVarNames
+		if !ctrl.contains(opts.EmbeddedVarNames, "target") {
+			opts.EmbeddedVarNames = append(opts.EmbeddedVarNames, "target")
+		}
 		if opts.UpdateCondition == "" {
 			opts.UpdateCondition = tpl.UpdateCondition
 		}
@@ -213,6 +226,9 @@ func (ctrl *PostController) getCommentParams(ctx context.Context, opts *option.P
 	}
 	for k, v := range opts.Vars {
 		cfg.Vars[k] = v
+	}
+	if cfg.Vars["target"] == nil {
+		cfg.Vars["target"] = ""
 	}
 
 	ci := ""

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -167,6 +167,11 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Aliases: []string{"s"},
 						Usage:   "suppress the output of dry-run and skip-no-token",
 					},
+					&cli.StringFlag{
+						Name:    "update-condition",
+						Aliases: []string{"u"},
+						Usage:   "update the comment that matches with the condition",
+					},
 				},
 			},
 			{

--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -28,6 +28,7 @@ func parseExecOptions(opts *option.ExecOptions, c *cli.Context) error {
 	opts.DryRun = c.Bool("dry-run")
 	opts.SkipNoToken = c.Bool("skip-no-token")
 	opts.Silent = c.Bool("silent")
+	opts.UpdateCondition = c.String("update-condition")
 	opts.LogLevel = c.String("log-level")
 
 	vars, err := parseVarsFlag(c.StringSlice("var"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,7 @@ type ExecConfig struct {
 	TemplateForTooLong string   `yaml:"template_for_too_long"`
 	DontComment        bool     `yaml:"dont_comment"`
 	EmbeddedVarNames   []string `yaml:"embedded_var_names"`
+	UpdateCondition    string   `yaml:"update"`
 }
 
 type ExistFile func(string) bool

--- a/pkg/option/exec.go
+++ b/pkg/option/exec.go
@@ -6,8 +6,9 @@ import (
 
 type ExecOptions struct {
 	Options
-	Args        []string
-	SkipComment bool
+	Args            []string
+	SkipComment     bool
+	UpdateCondition string
 }
 
 func ValidateExec(opts *ExecOptions) error {


### PR DESCRIPTION
## Description
Two functions have been added.
* When UpdateCondition is in effect in the post function, a special variable called target is added to the metadata to identify the comment to be updated.
  * When using the same template for several different jobs, the target variable can be used to avoid duplicate comments to be updated.
* Add UpdateCondition to the exec function as well, similar to post

## Test Case
### Post
```
$ HELLO=test1 go run ./cmd/github-comment post --org yuyaban --repo github-comment --pr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_A"
$ HELLO=test2 go run ./cmd/github-comment post --org yuyaban --repo github-comment --pr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_A"
$ HELLO=test1 go run ./cmd/github-comment post --org yuyaban --repo github-comment --pr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_B"
```
## Exec
```
$ go run ./cmd/github-comment exec --org yuyaban --repo github-comment --pr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_A" -- echo "test comment test1" 
$ go run ./cmd/github-comment exec --org yuyaban --repo github-comment --pr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_A" -- echo "test comment test2"
$ go run ./cmd/github-comment exec --org yuyaban --repo github-comment --pr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_B" -- echo "test comment test1"
```

